### PR TITLE
fix(validator): avoid infinite polling

### DIFF
--- a/components/validator/validator.go
+++ b/components/validator/validator.go
@@ -130,7 +130,6 @@ func (v *Validator) loop() {
 			}
 		case <-v.ctx.Done():
 			return
-		default:
 		}
 	}
 }


### PR DESCRIPTION
validator hits cpu usage 100% because select statement in Validator.loop() doesn't do what we expect. This should sleep and wake up at every tick.
