### PR TITLE
build: unify version format to {version}-{commit}

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,8 @@
-VERSION := $(shell git describe --tags --abbrev=0 --match v* 2> /dev/null || git rev-parse --short HEAD)
-GIT_COMMIT := $(shell git rev-parse HEAD)
-GIT_DATE := $(shell git show -s --format='%ct')
+VERSION := $(shell git describe --tags --abbrev=0 --match v* 2> /dev/null || echo 'v0.0.0')
+GIT_COMMIT := $(shell git rev-parse --short=8 HEAD)
 
 LD_FLAGS_ARGS +=-X main.Version=$(VERSION)
-LD_FLAGS_ARGS +=-X main.GitCommit=$(GIT_COMMIT)
-LD_FLAGS_ARGS +=-X main.GitDate=$(GIT_DATE)
+LD_FLAGS_ARGS +=-X main.Meta=$(GIT_COMMIT)
 LD_FLAGS := -ldflags "$(LD_FLAGS_ARGS)"
 
 build:

--- a/components/batcher/cmd/main.go
+++ b/components/batcher/cmd/main.go
@@ -7,15 +7,14 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/urfave/cli"
 
-	batcher "github.com/wemixkanvas/kanvas/components/batcher"
+	"github.com/wemixkanvas/kanvas/components/batcher"
 	"github.com/wemixkanvas/kanvas/components/batcher/flags"
 	klog "github.com/wemixkanvas/kanvas/utils/service/log"
 )
 
 var (
-	Version   = ""
-	GitCommit = ""
-	GitDate   = ""
+	Version = ""
+	Meta    = ""
 )
 
 func main() {
@@ -23,7 +22,7 @@ func main() {
 
 	app := cli.NewApp()
 	app.Flags = flags.Flags
-	app.Version = fmt.Sprintf("%s-%s-%s", Version, GitCommit, GitDate)
+	app.Version = fmt.Sprintf("%s-%s", Version, Meta)
 	app.Name = "kanvas-batcher"
 	app.Usage = "Batch Submitter Service"
 	app.Description = "Service for generating and submitting L2 tx batches " +

--- a/components/node/cmd/main.go
+++ b/components/node/cmd/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"os"
 	"os/signal"
@@ -26,23 +27,19 @@ import (
 )
 
 var (
-	GitCommit = ""
-	GitDate   = ""
+	Version = ""
+	Meta    = ""
 )
 
 // VersionWithMeta holds the textual version string including the metadata.
 var VersionWithMeta = func() string {
-	v := version.Version
-	if GitCommit != "" {
-		v += "-" + GitCommit[:8]
+	if Version != "" {
+		version.Version = Version
 	}
-	if GitDate != "" {
-		v += "-" + GitDate
+	if Meta != "" {
+		version.Meta = Meta
 	}
-	if version.Meta != "" {
-		v += "-" + version.Meta
-	}
-	return v
+	return fmt.Sprintf("%s-%s", version.Version, version.Meta)
 }()
 
 func main() {

--- a/components/node/cmd/stateviz/main.go
+++ b/components/node/cmd/stateviz/main.go
@@ -25,6 +25,11 @@ import (
 )
 
 var (
+	Version = ""
+	Meta    = ""
+)
+
+var (
 	snapshot   = flag.String("snapshot", "", "path to snapshot log")
 	listenAddr = flag.String("addr", "", "listen address of webserver")
 	refresh    = flag.Duration("refresh", 10*time.Second, "snapshot refresh rate")
@@ -98,6 +103,7 @@ func main() {
 	log.Root().SetHandler(
 		log.LvlFilterHandler(log.LvlDebug, log.StreamHandler(os.Stdout, log.TerminalFormat(true))),
 	)
+	log.Info("Starting stateviz...", "version", fmt.Sprintf("%s-%s", Version, Meta))
 
 	if *snapshot == "" {
 		log.Crit("missing required -snapshot flag")

--- a/components/node/version/version.go
+++ b/components/node/version/version.go
@@ -1,6 +1,6 @@
 package version
 
 var (
-	Version = "v0.1.0"
+	Version = "v0.0.0"
 	Meta    = "dev"
 )

--- a/components/validator/cmd/main.go
+++ b/components/validator/cmd/main.go
@@ -13,9 +13,8 @@ import (
 )
 
 var (
-	Version   = ""
-	GitCommit = ""
-	GitDate   = ""
+	Version = ""
+	Meta    = ""
 )
 
 func main() {
@@ -23,7 +22,7 @@ func main() {
 
 	app := cli.NewApp()
 	app.Flags = flags.Flags
-	app.Version = fmt.Sprintf("%s-%s-%s", Version, GitCommit, GitDate)
+	app.Version = fmt.Sprintf("%s-%s", Version, Meta)
 	app.Name = "validator"
 	app.Usage = "L2Output Submitter"
 	app.Description = "Service for generating and submitting L2 Output checkpoints to the L2OutputOracle contract"


### PR DESCRIPTION
This commit contains changes that unify the version format to `{version}-{commit}`