### PR TITLE
ci: add disable parallel option in e2e test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,8 @@ jobs:
         run: yarn build
 
       - name: Run Tests
+        env:
+          E2E_DISABLE_PARALLEL: true
         run: make test
 
       - name: Docker Image Name

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,4 +56,6 @@ jobs:
         run: yarn build
 
       - name: Run tests
+        env:
+          E2E_DISABLE_PARALLEL: true
         run: make test


### PR DESCRIPTION
Exclude unpredictable behavior due to the parallel environment during e2e test operation. 

Related #9, #10
